### PR TITLE
remove the font which doesn't work in the browser so well

### DIFF
--- a/app/assets/stylesheets/heading.scss
+++ b/app/assets/stylesheets/heading.scss
@@ -1,11 +1,10 @@
 .exfrasis-heading {
   text-transform: uppercase;
-  font-family: 'Walkway Ultracondensed';
 }
 
 h3.exfrasis-heading {
   display: inline-block;
-  font-size: 25px;
+  font-size: 23px;
   border-bottom: 1px solid black;
   margin-top: 25px;
   margin-bottom: 15px;
@@ -13,7 +12,7 @@ h3.exfrasis-heading {
 
 h2.exfrasis-heading {
   display: inline-block;
-  font-size: 18px;
+  font-size: 17px;
   margin-top: 25px;
   margin-bottom: 3px;
 }


### PR DESCRIPTION
this removes the walkaway ultracondensed from the titles
